### PR TITLE
Send message to inidividual by email

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,9 +156,8 @@ The API is generally RESTFUL and returns results in JSON.
   {
       subject: required
       message: required
-      status: required
+      emailTo: nullable
       senderId: nullable
-      receiverId: nullable
       parentMessageId: nullable
   }
   ```
@@ -183,6 +182,8 @@ The API is generally RESTFUL and returns results in JSON.
 - ##### Error Response
   - Status: `400`
   - error: `"Please input all required fields"`
+  - Status: `404`
+  - error: `"Email not found"`
 
 **[Back to top](#table-of-contents)**
 

--- a/server/controllers/messageControllers.js
+++ b/server/controllers/messageControllers.js
@@ -11,6 +11,12 @@ exports.postMessage = (req, res) => {
     });
   }
   const postMessage = messageServices.postMessage(req.body);
+  if (postMessage == 'NOT FOUND') {
+    return res.send({
+      status: 404,
+      error: 'Email not found',
+    });
+  }
   return res.send({
     status: 201,
     data: postMessage,

--- a/server/services/userServices.js
+++ b/server/services/userServices.js
@@ -40,4 +40,10 @@ export default class UserService {
     }
     return user;
   }
+
+  findUserByEmail(email) {
+    const users = this.fetchAll();
+    const foundUser = users.find((user) => user.email == email);
+    return foundUser;
+  }
 }

--- a/server/services/userServices.js
+++ b/server/services/userServices.js
@@ -44,6 +44,9 @@ export default class UserService {
   findUserByEmail(email) {
     const users = this.fetchAll();
     const foundUser = users.find((user) => user.email == email);
+    if (!foundUser) {
+      return 'error';
+    }
     return foundUser;
   }
 }

--- a/server/test/message.test.js
+++ b/server/test/message.test.js
@@ -31,7 +31,9 @@ describe('Test post a message service method', () => {
     expect(newMessage).to.have.property('id');
     expect(newMessage).to.have.property('message');
     expect(newMessage).to.have.property('subject');
-    expect(newMessage).to.have.property('status').eql('draft');
+    expect(newMessage)
+      .to.have.property('status')
+      .eql('draft');
     expect(newMessage).to.have.property('senderId');
     expect(newMessage).to.have.property('receiverId');
     expect(newMessage).to.have.property('parentMessageId');
@@ -61,7 +63,9 @@ describe('Test post a message service method', () => {
     expect(newMessage).to.have.property('subject');
     expect(newMessage).to.have.property('message');
     expect(newMessage).to.have.property('createdOn');
-    expect(newMessage).to.have.property('status').eql('sent');
+    expect(newMessage)
+      .to.have.property('status')
+      .eql('sent');
     expect(newMessage).to.have.property('senderId');
     expect(newMessage).to.have.property('receiverId');
     done();
@@ -91,8 +95,6 @@ describe('Test post a message route', () => {
   it('should return error if all the required fields arent passed along', (done) => {
     const dummyMessage = {
       message: 'Thanks for coming',
-      status: null,
-      parentMessageId: null,
     };
     chai
       .request(server)
@@ -103,14 +105,27 @@ describe('Test post a message route', () => {
         done();
       });
   });
-  it('sould create message when the required fields are present', (done) => {
+  it('should return error when the email user wants to send to cant be found', (done) => {
     const dummyMessage = {
       subject: 'Hello',
       message: 'Thanks for coming',
-      status: null,
-      parentMessageId: null,
-      senderId: 1,
-      receiverId: 2,
+      emailTo: 'jon@mail.com',
+      senderId: 2,
+    };
+    chai
+      .request(server)
+      .post('/api/v1/messages')
+      .send(dummyMessage)
+      .end((err, res) => {
+        expect(res.body.status).to.eql(404);
+        expect(res.body).to.have.property('error');
+        done();
+      });
+  });
+  it('sould create message as draft when emailTo isnt passed along', (done) => {
+    const dummyMessage = {
+      subject: 'Hello',
+      message: 'Thanks for coming',
     };
     chai
       .request(server)
@@ -123,7 +138,31 @@ describe('Test post a message route', () => {
         expect(res.body.data).to.have.property('subject');
         expect(res.body.data).to.have.property('message');
         expect(res.body.data).to.have.property('createdOn');
-        expect(res.body.data).to.have.property('status');
+        expect(res.body.data)
+          .to.have.property('status')
+          .eql('draft');
+        done();
+      });
+  });
+  it('should send a message to an inidividual when emailTo is passed along', (done) => {
+    const dummyMessage = {
+      subject: 'Hello',
+      message: 'Thanks for coming',
+      emailTo: 'superuser@mail.com',
+      senderId: 3,
+    };
+    chai
+      .request(server)
+      .post('/api/v1/messages')
+      .send(dummyMessage)
+      .end((err, res) => {
+        expect(res.body.status).to.eql(201);
+        expect(res.body.data).to.have.property('id');
+        expect(res.body.data).to.have.property('message');
+        expect(res.body.data).to.have.property('subject');
+        expect(res.body.data).to.have.property('receiverId');
+        expect(res.body.data).to.have.property('senderId');
+        expect(res.body.data).to.have.property('status').eql('sent');
         done();
       });
   });

--- a/server/test/message.test.js
+++ b/server/test/message.test.js
@@ -21,14 +21,38 @@ describe('Test that an array exists in all message service method', () => {
   });
 });
 describe('Test post a message service method', () => {
+  it('should return an object with senderId and receiverId as null if emailTo isnt passed along', (done) => {
+    const dummyMessage = {
+      subject: 'Hello',
+      message: 'Thanks for coming',
+    };
+    const newMessage = messageServices.postMessage(dummyMessage);
+    expect(newMessage).to.be.an('object');
+    expect(newMessage).to.have.property('id');
+    expect(newMessage).to.have.property('message');
+    expect(newMessage).to.have.property('subject');
+    expect(newMessage).to.have.property('status').eql('draft');
+    expect(newMessage).to.have.property('senderId');
+    expect(newMessage).to.have.property('receiverId');
+    expect(newMessage).to.have.property('parentMessageId');
+    done();
+  });
+  it('should return an error if an emailTo is passed along but the user isnt found', (done) => {
+    const dummyMessage = {
+      subject: 'Hello',
+      message: 'Thanks for coming',
+      emailTo: 'nouser@mail.com',
+      senderId: 2,
+    };
+    const newMessage = messageServices.postMessage(dummyMessage);
+    expect(newMessage).to.eql('NOT FOUND');
+  });
   it('should return a message object when correct details are passed', (done) => {
     const dummyMessage = {
       subject: 'Hello',
       message: 'Thanks for coming',
-      status: null,
-      parentMessageId: null,
-      senderId: 1,
-      receiverId: 2,
+      emailTo: 'superuser@mail.com',
+      senderId: 2,
     };
     const newMessage = messageServices.postMessage(dummyMessage);
     expect(newMessage).to.be.an('object');
@@ -36,7 +60,7 @@ describe('Test post a message service method', () => {
     expect(newMessage).to.have.property('subject');
     expect(newMessage).to.have.property('message');
     expect(newMessage).to.have.property('createdOn');
-    expect(newMessage).to.have.property('status');
+    expect(newMessage).to.have.property('status').eql('sent');
     expect(newMessage).to.have.property('senderId');
     expect(newMessage).to.have.property('receiverId');
     done();

--- a/server/test/message.test.js
+++ b/server/test/message.test.js
@@ -46,6 +46,7 @@ describe('Test post a message service method', () => {
     };
     const newMessage = messageServices.postMessage(dummyMessage);
     expect(newMessage).to.eql('NOT FOUND');
+    done();
   });
   it('should return a message object when correct details are passed', (done) => {
     const dummyMessage = {

--- a/server/test/user.test.js
+++ b/server/test/user.test.js
@@ -170,3 +170,18 @@ describe('Test user sign in route', () => {
       });
   });
 });
+
+describe('Test the find user by id method', () => {
+  it('should return return error if no user is found', (done) => {
+    const foundUser = userServices.findUserByEmail('false@email.com');
+    expect(foundUser).to.eql('error');
+    done();
+  });
+  it('should return the found user object if it finds the user', (done) => {
+    const foundUser = userServices.findUserByEmail('superuser@mail.com');
+    expect(foundUser).to.be.an('object');
+    expect(foundUser).to.have.property('id');
+    expect(foundUser).to.have.property('email');
+    done();
+  });
+});


### PR DESCRIPTION
### What does this PR do?

* Add functionality to send a message to an individual by email
* Removes need to pass in receiverId before one can send a message to an individual

### Type of change
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] Chore (a non-breaking change which doesn't affect existing functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of Task to be completed?

* add emailTo input for receiving the email of the message recipient
* Find user id with the email provided
* Send the message to them

### How should this be manually tested?

* git clone the repo
* npm install
* npm start
* send a POST request to `/api/v1/messages`

#### Any background context you want to provide?
The request body to the POST message should include `subject, message, senderId: optional, emailTo: optional`
if emailTo isn't added to request body, the message will be a draft 

### What are the relevant pivotal tracker stories?

#164490864