### PR TITLE
[#164564680]: Create a delete group route

### DIFF
--- a/server/controllers/groupControllers.js
+++ b/server/controllers/groupControllers.js
@@ -125,8 +125,40 @@ const removeMember = (req, res) => {
   });
 };
 
+const deleteGroup = (req, res) => {
+  const { groupid } = req.params;
+  // check if the group exists in the db
+  db.query('SELECT * FROM groups WHERE id = $1', [groupid], (err, group) => {
+    if (!group.rows[0]) {
+      return res.status(404).json({
+        status: 'Failed',
+        error: 'Group does not exist',
+      });
+    }
+    if (group.rows[0].adminid !== req.decoded.sub) {
+      return res.status(403).json({
+        status: 'Failed',
+        error: 'Error! Only group admin can delete group',
+      });
+    }
+    db.query(
+      'DELETE FROM groups WHERE id = $1',
+      [groupid],
+      (err, deletedGroup) => {
+        return res.status(200).json({
+          status: 'success',
+          data: {
+            message: 'Group deleted successfully',
+          },
+        });
+      }
+    );
+  });
+};
+
 module.exports = {
   addUserToGroup,
   postGroup,
   removeMember,
+  deleteGroup,
 };

--- a/server/routes/groupRoutes.js
+++ b/server/routes/groupRoutes.js
@@ -45,4 +45,6 @@ router.post('/:groupid/users/', tokenHandler.verifyToken, groupController.addUse
 
 router.delete('/:groupid/users/:userid', tokenHandler.verifyToken, groupController.removeMember)
 
+router.delete('/:groupid', tokenHandler.verifyToken, groupController.deleteGroup)
+
 export default router;

--- a/server/test/group.test.js
+++ b/server/test/group.test.js
@@ -232,7 +232,7 @@ describe('Test delete user from a group route', () => {
           .to.have.property('status')
           .to.eql('Failed');
         expect(res.body).to.have.property('error');
-        done()
+        done();
       });
   });
   it('should remove user from group when all conditions are met', (done) => {
@@ -242,9 +242,57 @@ describe('Test delete user from a group route', () => {
       .set('Authorization', userToken)
       .end((err, res) => {
         expect(res.status).to.eql(200);
-        expect(res.body).to.have.property('status').to.eql('success');
+        expect(res.body)
+          .to.have.property('status')
+          .to.eql('success');
         expect(res.body.data).to.have.property('message');
-        done()
+        done();
       });
-  })
+  });
+});
+
+describe('Test user delete group they own route', () => {
+  it('should return error when no group is found', (done) => {
+    chai
+      .request(server)
+      .delete('/api/v1/groups/5')
+      .set('Authorization', userToken)
+      .end((err, res) => {
+        expect(res.status).to.eql(404);
+        expect(res.body)
+          .to.have.property('status')
+          .to.eql('Failed');
+        expect(res.body).to.have.property('error');
+        done();
+      });
+  });
+  it('should return error when user who sends request is not the group admin', (done) => {
+    chai
+      .request(server)
+      .delete('/api/v1/groups/1')
+      .set('Authorization', secondToken)
+      .end((err, res) => {
+        expect(res.status).to.eql(403);
+        expect(res.body)
+          .to.have.property('status')
+          .to.eql('Failed');
+        expect(res.body).to.have.property('error');
+        done();
+      });
+  });
+  it('should delete group and return successs when all conditions are met', (done) => {
+    chai
+      .request(server)
+      .delete('/api/v1/groups/1')
+      .set('Authorization', userToken)
+      .end((err, res) => {
+        expect(res.status).to.eql(200);
+        expect(res.body)
+          .to.have.property('status')
+          .to.eql('success');
+        expect(res.body).to.have.property('data');
+        expect(res.body.data).to.have.property('message');
+        done();
+      });
+  });
 });


### PR DESCRIPTION
### What does this PR do?

* Add functionality to let user delete group they own

### Type of change
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] Chore (a non-breaking change which doesn't affect existing functionality)

### How should this be manually tested?

* git clone the repo
* npm install
* npm run dev
* send a POST request to `/api/v1/groups` to create a group
* send a DELETE request to `/api/v1/groups/:groupid` to delete the created group

### What are the relevant pivotal tracker stories?

#164564687