### PR TITLE
[#164790600]: Add feature to delete message in database

### DIFF
--- a/server/controllers/messageControllers.js
+++ b/server/controllers/messageControllers.js
@@ -228,6 +228,7 @@ exports.getUnreadMessages = (req, res) => {
 };
 
 exports.deleteById = (req, res) => {
+  const { sub } = req.decoded;
   // check if the message exists
   db.query(
     'SELECT * FROM messages WHERE id = $1',
@@ -240,24 +241,65 @@ exports.deleteById = (req, res) => {
         });
       }
       if (!message.rows[0]) {
-        return res.status(404)({
+        return res.status(404).json({
           status: 'failed',
           error: 'No message with that id found',
         });
       }
       if (
-        message.rows[0].senderid !== sub &&
-        message.rows[0].receiverid !== sub
+        message.rows[0].receiverid !== sub &&
+        message.rows[0].senderid !== sub
       ) {
-        return res.status(403)({
+        return res.status(403).json({
           status: 'failed',
           error:
             'Sorry, you can request a message only when you are the sender or receiver',
         });
       }
+      // const deleteMessage = () => {
+      //   return new Promise((resolve, reject) => {
+      //     if (message.rows[0].receiverid == sub) {
+      //       db.query(
+      //         'UPDATE messages SET receiverdeleted = $1 WHERE id = $2',
+      //         [1, req.params.id],
+      //         (err, removedMessage) => {
+      //           if (err) {
+      //             reject(err);
+      //           }
+      //           if (removedMessage.rows[0]) {
+      //             resolve(removedMessage);
+      //           }
+      //         }
+      //       );
+      //     } else if (message.rows[0].senderid == sub) {
+      //       db.query(
+      //         'DELETE FROM messages WHERE id = $1 RETURNING *',
+      //         [req.params.id],
+      //         (err, deletedMessage) => {
+      //           if (err) {
+      //             reject(err);
+      //           }
+      //           if (deletedMessage.rows[0]) {
+      //             resolve(deletedMessage);
+      //           }
+      //         }
+      //       );
+      //     }
+      //   });
+      // };
+      // const initializeDeleteMessage = deleteMessage();
+      // initializeDeleteMessage.then((result) => {
+      //   return res.status(200).json({
+      //     status: 'success',
+      //     data: {
+      //       message: 'Message deleted successfully',
+      //     },
+      //   });
+      // });
       if (message.rows[0].receiverid == sub) {
         db.query(
-          'UPDATE TABLE messages WHERE id = $1 SET receiverdeleted = 1',
+          'UPDATE messages SET receiverdeleted = $1 WHERE id = $2 RETURNING *',
+          [1, req.params.id],
           (err, removedMessage) => {
             if (err) {
               return res.status(500).json({
@@ -276,26 +318,29 @@ exports.deleteById = (req, res) => {
           }
         );
       }
-      db.query(
-        'DELETE FROM messages WHERE id = $1 RETURNING *',
-        [req.params.id],
-        (err, deletedMessage) => {
-          if (err) {
-            return res.status(500).json({
-              status: 'failed',
-              error: 'Internal server error',
-            });
+      if (message.rows[0].senderid == sub) {
+        console.log('#################### i am not supposed to get here, but i am')
+        db.query(
+          'DELETE FROM messages WHERE id = $1 RETURNING *',
+          [req.params.id],
+          (err, deletedMessage) => {
+            if (err) {
+              return res.status(500).json({
+                status: 'failed',
+                error: 'Internal server error',
+              });
+            }
+            if (deletedMessage.rows[0]) {
+              return res.status(200).json({
+                status: 'success',
+                data: {
+                  message: 'Message deleted successfully',
+                },
+              });
+            }
           }
-          if (deletedMessage.rows[0]) {
-            return res.status(200).json({
-              status: 'success',
-              data: {
-                message: 'Message deleted successfully',
-              },
-            });
-          }
-        }
-      );
+        );
+      }
     }
   );
 };

--- a/server/controllers/messageControllers.js
+++ b/server/controllers/messageControllers.js
@@ -279,7 +279,6 @@ exports.deleteById = (req, res) => {
         );
       }
       if (message.rows[0].senderid == sub) {
-        console.log('#################### i am not supposed to get here, but i am')
         db.query(
           'DELETE FROM messages WHERE id = $1 RETURNING *',
           [req.params.id],

--- a/server/controllers/messageControllers.js
+++ b/server/controllers/messageControllers.js
@@ -256,46 +256,6 @@ exports.deleteById = (req, res) => {
             'Sorry, you can request a message only when you are the sender or receiver',
         });
       }
-      // const deleteMessage = () => {
-      //   return new Promise((resolve, reject) => {
-      //     if (message.rows[0].receiverid == sub) {
-      //       db.query(
-      //         'UPDATE messages SET receiverdeleted = $1 WHERE id = $2',
-      //         [1, req.params.id],
-      //         (err, removedMessage) => {
-      //           if (err) {
-      //             reject(err);
-      //           }
-      //           if (removedMessage.rows[0]) {
-      //             resolve(removedMessage);
-      //           }
-      //         }
-      //       );
-      //     } else if (message.rows[0].senderid == sub) {
-      //       db.query(
-      //         'DELETE FROM messages WHERE id = $1 RETURNING *',
-      //         [req.params.id],
-      //         (err, deletedMessage) => {
-      //           if (err) {
-      //             reject(err);
-      //           }
-      //           if (deletedMessage.rows[0]) {
-      //             resolve(deletedMessage);
-      //           }
-      //         }
-      //       );
-      //     }
-      //   });
-      // };
-      // const initializeDeleteMessage = deleteMessage();
-      // initializeDeleteMessage.then((result) => {
-      //   return res.status(200).json({
-      //     status: 'success',
-      //     data: {
-      //       message: 'Message deleted successfully',
-      //     },
-      //   });
-      // });
       if (message.rows[0].receiverid == sub) {
         db.query(
           'UPDATE messages SET receiverdeleted = $1 WHERE id = $2 RETURNING *',

--- a/server/routes/messageRoutes.js
+++ b/server/routes/messageRoutes.js
@@ -163,5 +163,5 @@ router.get('/', tokenHandler.verifyToken,messageController.getReceivedMessages);
 router.get('/sent',tokenHandler.verifyToken ,messageController.getSentMessages);
 router.get('/unread', tokenHandler.verifyToken, messageController.getUnreadMessages);
 router.get('/:id', tokenHandler.verifyToken, messageController.getMessageById);
-// router.delete('/:id', messageController.deleteById);
+router.delete('/:id',tokenHandler.verifyToken,  messageController.deleteById);
 export default router;

--- a/server/test/message.test.js
+++ b/server/test/message.test.js
@@ -351,7 +351,7 @@ describe('Test DELETE message by id route', () => {
   it('should return error when the person requesting to delete the message is neither the sender nor receiver', (done) => {
     chai
       .request(server)
-      .delete('/api/v1/messages/1')
+      .delete('/api/v1/messages/2')
       .set('Authorization', thirdToken)
       .end((err, res) => {
         expect(res.status).to.eql(403);
@@ -365,7 +365,7 @@ describe('Test DELETE message by id route', () => {
   it('should return deleted successfully when the receiver is making the request', (done) => {
     chai
       .request(server)
-      .delete('/api/v1/messages/1')
+      .delete('/api/v1/messages/2')
       .set('Authorization', secondToken)
       .end((err, res) => {
         expect(res.status).to.eql(200);
@@ -380,7 +380,7 @@ describe('Test DELETE message by id route', () => {
   it('should delete message successfully when the sender is making the request', (done) => {
     chai
       .request(server)
-      .delete('/api/v1/messages/1')
+      .delete('/api/v1/messages/2')
       .set('Authorization', userToken)
       .end((err, res) => {
         expect(res.status).to.eql(200);

--- a/server/test/message.test.js
+++ b/server/test/message.test.js
@@ -391,7 +391,7 @@ describe('Test DELETE message by id route', () => {
         expect(res.body.data).to.have.property('message');
         done();
       });
-  })
+  });
 });
 
 describe('Test errors returned when database is down', () => {
@@ -416,7 +416,7 @@ describe('Test errors returned when database is down', () => {
         done();
       });
   });
-  it('should test for error on login page when database is down', (done) => {
+  it('should test for error on get unread message route when database is down', (done) => {
     chai
       .request(server)
       .get('/api/v1/messages/unread')

--- a/server/test/message.test.js
+++ b/server/test/message.test.js
@@ -432,4 +432,20 @@ describe('Test errors returned when database is down', () => {
         done();
       });
   });
+  it('should test for error on delete message by id route when server is down', (done) => {
+    chai
+      .request(server)
+      .delete('/api/v1/messages/1')
+      .set('Authorization', secondToken)
+      .end((err, res) => {
+        expect(res.status).to.eql(500);
+        expect(res.body)
+          .to.have.property('status')
+          .to.eql('failed');
+        expect(res.body)
+          .to.have.property('error')
+          .to.eql('Internal server error');
+        done();
+      });
+  });
 });

--- a/server/test/message.test.js
+++ b/server/test/message.test.js
@@ -102,7 +102,7 @@ describe('Test post a message route', () => {
       .request(server)
       .post('/api/v1/messages')
       .set('Authorization', userToken)
-      .send({subject: 'Hello dear'})
+      .send({ subject: 'Hello dear' })
       .end((err, res) => {
         expect(res.status).to.eql(400);
         expect(res.body).to.have.property('error');
@@ -119,7 +119,7 @@ describe('Test post a message route', () => {
       .set('Authorization', userToken)
       .send(dummyMessage)
       .end((err, res) => {
-        expect(res.status).to.eql(422)
+        expect(res.status).to.eql(422);
         expect(res.body).to.have.property('error');
         done();
       });
@@ -331,6 +331,67 @@ describe('Test  get all unread messages route', () => {
         done();
       });
   });
+});
+
+describe('Test DELETE message by id route', () => {
+  it('should return no message found if id is incorrect', (done) => {
+    chai
+      .request(server)
+      .delete('/api/v1/messages/999')
+      .set('Autorization', userToken)
+      .end((err, res) => {
+        expect(res.status).to.eql(404);
+        expect(res.body)
+          .to.have.property('status')
+          .to.eql('failed');
+        expect(res.body).to.have.property('error');
+        done();
+      });
+  });
+  it('should return error when the person requesting to delete the message is neither the sender nor receiver', (done) => {
+    chai
+      .request(server)
+      .delete('/api/v1/messages/1')
+      .set('Autorization', thirdToken)
+      .end((err, res) => {
+        expect(res.status).to.eql(403);
+        expect(res.body)
+          .to.have.property('status')
+          .to.eql('failed');
+        expect(res.body).to.have.property('error');
+        done();
+      });
+  });
+  it('should return deleted successfully when the receiver is making the request', (done) => {
+    chai
+      .request(server)
+      .delete('/api/v1/messages/1')
+      .set('Autorization', secondToken)
+      .end((err, res) => {
+        expect(res.status).to.eql(200);
+        expect(res.body)
+          .to.have.property('status')
+          .to.eql('success');
+        expect(res.body).to.have.property('data');
+        expect(res.body.data).to.have.property('message');
+        done();
+      });
+  });
+  it('should delete message successfully when the sender is making the request', (done) => {
+    chai
+      .request(server)
+      .delete('/api/v1/messages/1')
+      .set('Autorization', userToken)
+      .end((err, res) => {
+        expect(res.status).to.eql(200);
+        expect(res.body)
+          .to.have.property('status')
+          .to.eql('success');
+        expect(res.body).to.have.property('data');
+        expect(res.body.data).to.have.property('message');
+        done();
+      });
+  })
 });
 
 describe('Test errors returned when database is down', () => {

--- a/server/test/message.test.js
+++ b/server/test/message.test.js
@@ -338,7 +338,7 @@ describe('Test DELETE message by id route', () => {
     chai
       .request(server)
       .delete('/api/v1/messages/999')
-      .set('Autorization', userToken)
+      .set('Authorization', userToken)
       .end((err, res) => {
         expect(res.status).to.eql(404);
         expect(res.body)
@@ -352,7 +352,7 @@ describe('Test DELETE message by id route', () => {
     chai
       .request(server)
       .delete('/api/v1/messages/1')
-      .set('Autorization', thirdToken)
+      .set('Authorization', thirdToken)
       .end((err, res) => {
         expect(res.status).to.eql(403);
         expect(res.body)
@@ -366,7 +366,7 @@ describe('Test DELETE message by id route', () => {
     chai
       .request(server)
       .delete('/api/v1/messages/1')
-      .set('Autorization', secondToken)
+      .set('Authorization', secondToken)
       .end((err, res) => {
         expect(res.status).to.eql(200);
         expect(res.body)
@@ -381,7 +381,7 @@ describe('Test DELETE message by id route', () => {
     chai
       .request(server)
       .delete('/api/v1/messages/1')
-      .set('Autorization', userToken)
+      .set('Authorization', userToken)
       .end((err, res) => {
         expect(res.status).to.eql(200);
         expect(res.body)


### PR DESCRIPTION
### What does this PR do?

* Add functionality to delete a user's message in the database

### Type of change
- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (non-breaking change which doesn't affect existing functionality)

### How should this be manually tested?

* git clone the repo
* npm install
* npm run dev
* send a POST request to `/api/v1/messages` to send a message
* send a DELETE request to `/api/v1/messages/:id` to delete the message

### Any background context you want to provide?
User can only delete a message when they are the receiver or the sender

### What are the relevant pivotal tracker stories?

#164790600